### PR TITLE
syncronize sql query with struct declaration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ name = "postgres-mapper"
 repository = "https://github.com/zeyla/postgres-mapper.git"
 version = "0.1.0"
 
+[lib]
+doctest = false
+
 [badges.maintenance]
 status = "actively-developed"
 
@@ -24,3 +27,4 @@ version = "0.3"
 default = ["postgres-support"]
 postgres-support = ["postgres"]
 tokio-postgres-support = ["tokio-postgres"]
+

--- a/README.md
+++ b/README.md
@@ -48,16 +48,30 @@ extern crate postgres_mapper;
 use postgres_mapper::FromPostgresRow;
 
 #[derive(PostgresMapper)]
+#[pg_mapper(table = "user")]
 pub struct User {
     pub id: i64,
     pub name: String,
     pub email: Option<String>,
 }
 
-// code to execute a query here and get back a row
+// Code to execute a query here and get back a row might now look like:
+let stmt = "SELECT {$1} FROM users
+    WHERE username = {$2} AND password = {$3}";
 
-// `postgres_mapper::FromPostgresRow`'s methods do not panic and return a Result
-let user = User::from_postgres_row(row)?;
+let rows = &self
+    .conn
+    .query(stmt, &[&db_types::User::sql_fields(), username, pass])
+    .unwrap();
+
+let user = rows
+    .iter()
+    .next()
+    .map(|row|
+      // `postgres_mapper::FromPostgresRow`'s methods do not panic and return a Result
+      User::from_postgres_row(row)?
+    );
+
 ```
 
 ### The two crates

--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@ pub struct User {
 }
 
 // Code to execute a query here and get back a row might now look like:
-let stmt = "SELECT {$1} FROM users
-    WHERE username = {$2} AND password = {$3}";
+let stmt = "SELECT {$1} FROM {$2}
+    WHERE username = {$3} AND password = {$4}";
 
 let rows = &self
     .conn
-    .query(stmt, &[&db_types::User::sql_fields(), username, pass])
-    .unwrap();
+    .query(
+        stmt,
+        &[&User::sql_fields(), &User::sql_table(), username, pass],
+    ).unwrap();
 
 let user = rows
     .iter()

--- a/postgres_mapper_derive/Cargo.toml
+++ b/postgres_mapper_derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 quote = "0.3"
-syn = "0.11"
+syn = "0.15"
 
 [features]
 default = []

--- a/postgres_mapper_derive/src/lib.rs
+++ b/postgres_mapper_derive/src/lib.rs
@@ -1,18 +1,21 @@
 extern crate quote;
 extern crate proc_macro;
+#[macro_use]
 extern crate syn;
 
 use proc_macro::TokenStream;
 use quote::Tokens;
-use syn::{Body, DeriveInput, VariantData};
 
-#[cfg(any(feature = "postgres-support", feature = "tokio-postgres-support"))]
-use syn::{Field, Ident};
+use syn::DeriveInput;
+use syn::Meta::{List, NameValue};
+use syn::NestedMeta::{Literal, Meta};
+use syn::Data::*;
 
-#[proc_macro_derive(PostgresMapper)]
+use syn::{Fields, Ident};
+
+#[proc_macro_derive(PostgresMapper, attributes(pg_mapper))]
 pub fn postgres_mapper(input: TokenStream) -> TokenStream {
-    let s = input.to_string();
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = parse_macro_input!(input as DeriveInput);
 
     impl_derive(&ast)
         .parse()
@@ -23,13 +26,19 @@ fn impl_derive(ast: &DeriveInput) -> Tokens {
     #[allow(unused_mut)]
     let mut tokens = Tokens::new();
 
+
+
     #[allow(unused_variables)]
-    let fields = match ast.body {
-        Body::Struct(VariantData::Struct(ref fields)) => fields,
-        Body::Struct(VariantData::Tuple(_)) => panic!("Tuple-structs not supported"),
-        Body::Struct(VariantData::Unit) => panic!("Unit structs not supported"),
-        Body::Enum(_) => panic!("Enums can not be mapped"),
+    let fields: &Fields = match ast.data {
+        Struct(ref s) => {
+            &s.fields
+        },
+        Enum(ref u) => {panic!("Enums can not be mapped")},
+        Union(ref u) => {panic!("Unions can not be mapped")},
     };
+
+    #[allow(unused_variables)]
+    let table_name = parse_table_attr(&ast);
 
     #[cfg(feature = "postgres-support")]
     {
@@ -38,7 +47,7 @@ fn impl_derive(ast: &DeriveInput) -> Tokens {
 
         #[cfg(feature = "postgres-mapper")]
         {
-            impl_postgres_mapper(&mut tokens, &ast.ident, &fields);
+            impl_postgres_mapper(&mut tokens, &ast.ident, &fields, &table_name);
         }
     }
 
@@ -49,7 +58,7 @@ fn impl_derive(ast: &DeriveInput) -> Tokens {
 
         #[cfg(feature = "postgres-mapper")]
         {
-            impl_tokio_postgres_mapper(&mut tokens, &ast.ident, &fields);
+            impl_tokio_postgres_mapper(&mut tokens, &ast.ident, &fields, &table_name);
         }
     }
 
@@ -57,7 +66,7 @@ fn impl_derive(ast: &DeriveInput) -> Tokens {
 }
 
 #[cfg(feature = "postgres-support")]
-fn impl_from_row(t: &mut Tokens, struct_ident: &Ident, fields: &[Field]) {
+fn impl_from_row(t: &mut Tokens, struct_ident: &Ident, fields: &Fields) {
     t.append(format!("
 impl<'a> From<::postgres::rows::Row<'a>> for {struct_name} {{
     fn from(row: ::postgres::rows::Row<'a>) -> Self {{
@@ -77,7 +86,7 @@ impl<'a> From<::postgres::rows::Row<'a>> for {struct_name} {{
 }
 
 #[cfg(feature = "postgres-support")]
-fn impl_from_borrowed_row(t: &mut Tokens, struct_ident: &Ident, fields: &[Field]) {
+fn impl_from_borrowed_row(t: &mut Tokens, struct_ident: &Ident, fields: &Fields) {
     t.append(format!("
 impl<'a> From<&'a ::postgres::rows::Row<'a>> for {struct_name} {{
     fn from(row: &::postgres::rows::Row<'a>) -> Self {{
@@ -97,7 +106,7 @@ impl<'a> From<&'a ::postgres::rows::Row<'a>> for {struct_name} {{
 }
 
 #[cfg(all(feature = "postgres-support", feature = "postgres-mapper"))]
-fn impl_postgres_mapper(t: &mut Tokens, struct_ident: &Ident, fields: &[Field]) {
+fn impl_postgres_mapper(t: &mut Tokens, struct_ident: &Ident, fields: &Fields, table_name: &str) {
     t.append(format!("
 impl ::postgres_mapper::FromPostgresRow for {struct_name} {{
     fn from_postgres_row(row: ::postgres::rows::Row)
@@ -128,12 +137,30 @@ impl ::postgres_mapper::FromPostgresRow for {struct_name} {{
 
     t.append("
         })
-    }
+    }");
+
+    t.append(
+    format!(
+    "fn sql_fields() -> String {{")
+    );
+
+    let field_name = fields.iter().map(|field| {
+        let ident = field.ident.clone().expect("Expected structfield identifier");
+        format!("{0}.{1}", table_name, ident)
+    }).collect::<Vec<String>>().join(", ");
+
+    t.append(format!("\" {0} \".to_string()", field_name));
+
+    t.append(
+    "}"
+    );
+
+    t.append("
 }");
 }
 
 #[cfg(feature = "tokio-postgres-support")]
-fn impl_tokio_from_row(t: &mut Tokens, struct_ident: &Ident, fields: &[Field]) {
+fn impl_tokio_from_row(t: &mut Tokens, struct_ident: &Ident, fields: &Fields) {
     t.append(format!("
 impl From<::tokio_postgres::Row> for {struct_name} {{
     fn from(row: ::tokio_postgres::Row) -> Self {{
@@ -153,7 +180,7 @@ impl From<::tokio_postgres::Row> for {struct_name} {{
 }
 
 #[cfg(feature = "tokio-postgres-support")]
-fn impl_tokio_from_borrowed_row(t: &mut Tokens, struct_ident: &Ident, fields: &[Field]) {
+fn impl_tokio_from_borrowed_row(t: &mut Tokens, struct_ident: &Ident, fields: &Fields) {
     t.append(format!("
 impl<'a> From<&'a ::tokio_postgres::Row> for {struct_name} {{
     fn from(row: &'a ::tokio_postgres::Row) -> Self {{
@@ -177,7 +204,7 @@ impl<'a> From<&'a ::tokio_postgres::Row> for {struct_name} {{
 fn impl_tokio_postgres_mapper(
     t: &mut Tokens,
     struct_ident: &Ident,
-    fields: &[Field],
+    fields: &Fields,
 ) {
     t.append(format!("
 impl ::postgres_mapper::FromTokioPostgresRow for {struct_name} {{
@@ -209,6 +236,87 @@ impl ::postgres_mapper::FromTokioPostgresRow for {struct_name} {{
 
     t.append("
         })
-    }
+    }");
+
+    t.append(
+    format!(
+    "fn sql_fields() -> String {{")
+    );
+
+    let field_name = fields.iter().map(|field| {
+        let ident = field.ident.clone().expect("Expected structfield identifier");
+        format!("{0}.{1}", table_name, ident)
+    }).collect::<Vec<String>>().join(", ");
+
+    t.append(format!("\" {0} \".to_string()", field_name));
+
+    t.append(
+    "}"
+    );
+
+    t.append("
 }");
 }
+
+fn get_mapper_meta_items(attr: &syn::Attribute) -> Option<Vec<syn::NestedMeta>> {
+    if attr.path.segments.len() == 1 && attr.path.segments[0].ident == "pg_mapper" {
+        match attr.interpret_meta() {
+            Some(List(ref meta)) => Some(meta.nested.iter().cloned().collect()),
+            _ => {
+                panic!("declare table name: #[pg_mapper(table = \"foo\")]");
+            }
+        }
+    } else {
+        None
+    }
+}
+
+fn get_lit_str<'a>(
+    attr_name: &Ident,
+    meta_item_name: &Ident,
+    lit: &'a syn::Lit,
+) -> Result<&'a syn::LitStr, ()> {
+    if let syn::Lit::Str(ref lit) = *lit {
+        Ok(lit)
+    } else {
+        panic!(format!(
+            "expected pg_mapper {} attribute to be a string: `{} = \"...\"`",
+            attr_name, meta_item_name
+        ));
+        #[allow(unreachable_code)]
+        Err(())
+    }
+}
+
+fn parse_table_attr(ast: &DeriveInput) -> String {
+    // Parse `#[pg_mapper(table = "foo")]`
+    let mut table_name: Option<String> = None;
+
+    for meta_items in ast.attrs.iter().filter_map(get_mapper_meta_items) {
+
+        for meta_item in meta_items {
+            match meta_item {
+                // Parse `#[pg_mapper(table = "foo")]`
+                Meta(NameValue(ref m)) if m.ident == "table" => {
+                    if let Ok(s) = get_lit_str(&m.ident, &m.ident, &m.lit) {
+                        table_name = Some(s.value());
+                    }
+                }
+
+                Meta(ref meta_item) => {
+                    panic!(format!(
+                        "unknown pg_mapper container attribute `{}`",
+                        meta_item.name()
+                    ))
+                }
+
+                Literal(_) => {
+                    panic!("unexpected literal in pg_mapper container attribute");
+                }
+            }
+        }
+    }
+
+    table_name.expect("declare table name: #[pg_mapper(table = \"foo\")]")
+}
+

--- a/postgres_mapper_derive/src/lib.rs
+++ b/postgres_mapper_derive/src/lib.rs
@@ -139,6 +139,12 @@ impl ::postgres_mapper::FromPostgresRow for {struct_name} {{
         })
     }");
 
+    t.append(format!(
+    "fn sql_table() -> String {{
+        \" {0} \".to_string()
+    }}"
+    , table_name));
+
     t.append(
     format!(
     "fn sql_fields() -> String {{")
@@ -237,6 +243,12 @@ impl ::postgres_mapper::FromTokioPostgresRow for {struct_name} {{
     t.append("
         })
     }");
+
+    t.append(format!(
+    "fn sql_table() -> String {{
+        \" {0} \".to_string()
+    }}"
+    , table_name));
 
     t.append(
     format!(

--- a/postgres_mapper_derive/src/lib.rs
+++ b/postgres_mapper_derive/src/lib.rs
@@ -168,8 +168,8 @@ impl ::postgres_mapper::FromPostgresRow for {struct_name} {{
 #[cfg(feature = "tokio-postgres-support")]
 fn impl_tokio_from_row(t: &mut Tokens, struct_ident: &Ident, fields: &Fields) {
     t.append(format!("
-impl From<::tokio_postgres::Row> for {struct_name} {{
-    fn from(row: ::tokio_postgres::Row) -> Self {{
+impl From<::tokio_postgres::rows::Row> for {struct_name} {{
+    fn from(row: ::tokio_postgres::rows::Row) -> Self {{
         Self {{", struct_name=struct_ident));
 
     for field in fields {
@@ -188,8 +188,8 @@ impl From<::tokio_postgres::Row> for {struct_name} {{
 #[cfg(feature = "tokio-postgres-support")]
 fn impl_tokio_from_borrowed_row(t: &mut Tokens, struct_ident: &Ident, fields: &Fields) {
     t.append(format!("
-impl<'a> From<&'a ::tokio_postgres::Row> for {struct_name} {{
-    fn from(row: &'a ::tokio_postgres::Row) -> Self {{
+impl<'a> From<&'a ::tokio_postgres::rows::Row> for {struct_name} {{
+    fn from(row: &'a ::tokio_postgres::rows::Row) -> Self {{
         Self {{", struct_name=struct_ident));
 
     for field in fields {
@@ -211,10 +211,11 @@ fn impl_tokio_postgres_mapper(
     t: &mut Tokens,
     struct_ident: &Ident,
     fields: &Fields,
+    table_name: &str,
 ) {
     t.append(format!("
 impl ::postgres_mapper::FromTokioPostgresRow for {struct_name} {{
-    fn from_tokio_postgres_row(row: ::tokio_postgres::Row)
+    fn from_tokio_postgres_row(row: ::tokio_postgres::rows::Row)
         -> Result<Self, ::postgres_mapper::Error> {{
         Ok(Self {{", struct_name=struct_ident));
 
@@ -229,7 +230,7 @@ impl ::postgres_mapper::FromTokioPostgresRow for {struct_name} {{
         })
     }
 
-    fn from_tokio_postgres_row_ref(row: &::tokio_postgres::Row)
+    fn from_tokio_postgres_row_ref(row: &::tokio_postgres::rows::Row)
         -> Result<Self, ::postgres_mapper::Error> {
         Ok(Self {");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,22 @@ pub trait FromPostgresRow: Sized {
     /// [`Error::Postgres`]: enum.Error.html#variant.Postgres
     fn from_postgres_row_ref(row: &PostgresRow) -> Result<Self, Error>;
 
+    /// Get the name of the annotated sql table name.
+    ///
+    /// Example:
+    ///
+    /// The following will return the String " user ".
+    /// Note the extra spaces on either side to avoid incorrect formatting.
+    ///
+    /// ```
+    ///     #[derive(PostgresMapper)]
+    ///     #[pg_mapper(table = "user")]
+    ///     pub struct User {
+    ///         pub id: i64,
+    ///         pub email: Option<String>,
+    ///     }
+    /// ```
+    fn sql_table() -> String;
 
     /// Get a list of the field names which can be used to construct
     /// a SQL query.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,6 @@ pub trait FromPostgresRow: Sized {
     ///     }
     /// ```
     ///
-    ///
     fn sql_fields() -> String;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,45 @@ pub trait FromTokioPostgresRow: Sized {
     /// [`Error::ColumnNotFound`]: enum.Error.html#variant.ColumnNotFound
     /// [`Error::Conversion`]: enum.Error.html#variant.Conversion
     fn from_tokio_postgres_row_ref(row: &TokioRow) -> Result<Self, Error>;
+
+    /// Get the name of the annotated sql table name.
+    ///
+    /// Example:
+    ///
+    /// The following will return the String " user ".
+    /// Note the extra spaces on either side to avoid incorrect formatting.
+    ///
+    /// ```
+    ///     #[derive(PostgresMapper)]
+    ///     #[pg_mapper(table = "user")]
+    ///     pub struct User {
+    ///         pub id: i64,
+    ///         pub email: Option<String>,
+    ///     }
+    /// ```
+    fn sql_table() -> String;
+
+    /// Get a list of the field names which can be used to construct
+    /// a SQL query.
+    ///
+    /// We also expect an attribute tag #[pg_mapper(table = "foo")]
+    /// so that a scoped list of fields can be generated.
+    ///
+    /// Example:
+    ///
+    /// The following will return the String " user.id, user.email ".
+    /// Note the extra spaces on either side to avoid incorrect formatting.
+    ///
+    /// ```
+    ///     #[derive(PostgresMapper)]
+    ///     #[pg_mapper(table = "user")]
+    ///     pub struct User {
+    ///         pub id: i64,
+    ///         pub email: Option<String>,
+    ///     }
+    /// ```
+    ///
+    fn sql_fields() -> String;
 }
 
 /// General error type returned throughout the library.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,30 @@ pub trait FromPostgresRow: Sized {
     /// [`Error::ColumnNotFound`]: enum.Error.html#variant.ColumnNotFound
     /// [`Error::Postgres`]: enum.Error.html#variant.Postgres
     fn from_postgres_row_ref(row: &PostgresRow) -> Result<Self, Error>;
+
+
+    /// Get a list of the field names which can be used to construct
+    /// a SQL query.
+    ///
+    /// We also expect an attribute tag #[pg_mapper(table = "foo")]
+    /// so that a scoped list of fields can be generated.
+    ///
+    /// Example:
+    ///
+    /// The following will return the String " user.id, user.email ".
+    /// Note the extra spaces on either side to avoid incorrect formatting.
+    ///
+    /// ```
+    ///     #[derive(PostgresMapper)]
+    ///     #[pg_mapper(table = "user")]
+    ///     pub struct User {
+    ///         pub id: i64,
+    ///         pub email: Option<String>,
+    ///     }
+    /// ```
+    ///
+    ///
+    fn sql_fields() -> String;
 }
 
 /// Trait containing various methods for converting from a `tokio-postgres` Row


### PR DESCRIPTION
Thanks for the awesome idea and initial work! I ran into some bugs during usage and though there might be a way to avoid them.

This is my first work with proc macros so please excuse any mistakes. I was looking at the examples/docs for `syn` and it assumed recent version so I updated this lib to work with the most recent version of syn. I tried to keep the changes to a minimum.

Also I can't claim all this code is mine. I drew heavy inspiration from `serde_derive` and copied some code directly from here: https://github.com/serde-rs/serde/blob/fecfabb168afb9f0212f3035b26e335e0676b4ca/serde_derive/src/internals/attr.rs

Also found a bug during testing: https://github.com/zeyla/postgres-mapper/commit/999e71ef78e1c127e386157a58f576e3589a6f3f

## Existing usage:
Lets say we have a struct User we want to query.

```
#[derive(PostgresMapper)]
struct User {
  id: i64,
  name: String,
}

SELECT from users id, name where id = 1;
let user = User::from_postgres_row(row);
```

------
The above works until we want to query some additional information:

```
struct User {
  id: i64,
  name: String,
  age: i32
}
```

The code compiles! But SQL will throw at runtime!
`Err(DatabaseErr("Column in row not found"))`

## New usage:
Added an example in the Readme
